### PR TITLE
Add const keyword so that compilation succeeds on clang.

### DIFF
--- a/include/runn.h
+++ b/include/runn.h
@@ -203,7 +203,7 @@ void hRort(const long n,X *ra,Y *rb) {
 template<class T>
 class SCmp : binary_function<T,T,bool> {
 public:
-   bool operator() (T s,T t){
+   bool operator() (T s,T t) const {
       int i = strcmp(s,t);
       if(i<0)return true;
       else return false;


### PR DESCRIPTION
In this case, const keyword is required, the fact it compiles on g++ seems to be an issue with gcc.