### PR TITLE
Check MAP_NORESERVE for FreeBSD 14

### DIFF
--- a/lib/FBase.C
+++ b/lib/FBase.C
@@ -1,5 +1,9 @@
 #include <FBase.h>
 
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0
+#endif
+
 using namespace std;
 namespace iret {
 


### PR DESCRIPTION
I have noticed that _NCBITextLib_ uses MAP_NORESERVE flag in FBase.C. This flag is not present in modern FreeBSD (see [mmap](https://man.freebsd.org/cgi/man.cgi?query=mmap&apropos=0&sektion=2&manpath=FreeBSD+14.0-RELEASE&arch=default&format=html)). Therefore, _NCBITextLib_ compilation fails.
I have added two lines that check if it is defined and sets it to zero if not.